### PR TITLE
Prometheus Metrics

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/heptio/eventrouter",
 	"GoVersion": "go1.7",
-	"GodepVersion": "v79",
+	"GodepVersion": "v75",
 	"Packages": [
 		"./..."
 	],
@@ -14,6 +14,10 @@
 		{
 			"ImportPath": "github.com/PuerkitoBio/urlesc",
 			"Rev": "5bd2802263f21d8788851d5305584c82a5c75d7e"
+		},
+		{
+			"ImportPath": "github.com/beorn7/perks/quantile",
+			"Rev": "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
 		},
 		{
 			"ImportPath": "github.com/davecgh/go-spew/spew",
@@ -82,6 +86,10 @@
 		{
 			"ImportPath": "github.com/golang/glog",
 			"Rev": "44145f04b68cf362d9c4df2182967c2275eaefed"
+		},
+		{
+			"ImportPath": "github.com/golang/protobuf/proto",
+			"Rev": "98fa357170587e470c5f27d3c3ea0947b71eb455"
 		},
 		{
 			"ImportPath": "github.com/google/gofuzz",
@@ -158,6 +166,11 @@
 			"Rev": "d5b7844b561a7bc640052f1b935f7b800330d7e0"
 		},
 		{
+			"ImportPath": "github.com/matttproud/golang_protobuf_extensions/pbutil",
+			"Comment": "v1.0.0-2-gc12348c",
+			"Rev": "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+		},
+		{
 			"ImportPath": "github.com/mitchellh/mapstructure",
 			"Rev": "53818660ed4955e899c0bcafa97299a388bd7c8e"
 		},
@@ -178,6 +191,37 @@
 		{
 			"ImportPath": "github.com/pkg/sftp",
 			"Rev": "4d0e916071f68db74f8a73926335f809396d6b42"
+		},
+		{
+			"ImportPath": "github.com/prometheus/client_golang/prometheus",
+			"Comment": "v0.8.0-11-g134be0b",
+			"Rev": "134be0b97877dd62a2970c5d79731d5e97ee6b9d"
+		},
+		{
+			"ImportPath": "github.com/prometheus/client_golang/prometheus/promhttp",
+			"Comment": "v0.8.0-11-g134be0b",
+			"Rev": "134be0b97877dd62a2970c5d79731d5e97ee6b9d"
+		},
+		{
+			"ImportPath": "github.com/prometheus/client_model/go",
+			"Comment": "model-0.0.2-12-gfa8ad6f",
+			"Rev": "fa8ad6fec33561be4280a8f0514318c79d7f6cb6"
+		},
+		{
+			"ImportPath": "github.com/prometheus/common/expfmt",
+			"Rev": "85637ea67b04b5c3bb25e671dacded2977f8f9f6"
+		},
+		{
+			"ImportPath": "github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg",
+			"Rev": "85637ea67b04b5c3bb25e671dacded2977f8f9f6"
+		},
+		{
+			"ImportPath": "github.com/prometheus/common/model",
+			"Rev": "85637ea67b04b5c3bb25e671dacded2977f8f9f6"
+		},
+		{
+			"ImportPath": "github.com/prometheus/procfs",
+			"Rev": "abf152e5f3e97f2fafac028d2cc06c1feb87ffa5"
 		},
 		{
 			"ImportPath": "github.com/spf13/afero",

--- a/Makefile
+++ b/Makefile
@@ -22,20 +22,20 @@ DOCKER ?= docker
 DIR := ${CURDIR}
 
 all: local container
-	
-local: 
+
+local:
 	$(DOCKER) run --rm -v $(DIR):$(BUILDMNT) -w $(BUILDMNT) $(BUILD_IMAGE) go build -v
 
 container:
 	$(DOCKER) build -t $(REGISTRY)/$(TARGET):latest -t $(REGISTRY)/$(TARGET):$(VERSION) .
 
 # TODO: Determine tagging mechanics
-push: 
+push:
 	docker -- push $(REGISTRY)/$(TARGET)
 
 .PHONY: all local container push
 
-clean: 
+clean:
 	rm -f $(TARGET)
 	$(DOCKER) rmi $(REGISTRY)/$(TARGET):latest
 	$(DOCKER) rmi $(REGISTRY)/$(TARGET):$(VERSION)

--- a/eventrouter.go
+++ b/eventrouter.go
@@ -151,7 +151,7 @@ func prometheusEvent(event *v1.Event) {
 
 	if err != nil {
 		// Not sure this is the right place to log this error?
-		glog.Error(err)
+		glog.Warning(err)
 	} else {
 		counter.Add(1)
 	}

--- a/main.go
+++ b/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"flag"
-	"log"
 	"net/http"
 	"os"
 	"os/signal"
@@ -111,9 +110,9 @@ func main() {
 
 	// Startup the http listener for Prometheus Metrics endpoint.
 	go func() {
-		log.Println("Starting prometheus metrics.")
+		glog.Info("Starting prometheus metrics.")
 		http.Handle("/metrics", promhttp.Handler())
-		log.Print(http.ListenAndServe(*addr, nil))
+		glog.Warning(http.ListenAndServe(*addr, nil))
 	}()
 
 	// Startup the EventRouter

--- a/main.go
+++ b/main.go
@@ -111,6 +111,7 @@ func main() {
 
 	// Startup the http listener for Prometheus Metrics endpoint.
 	go func() {
+		log.Println("Starting prometheus metrics.")
 		http.Handle("/metrics", promhttp.Handler())
 		log.Print(http.ListenAndServe(*addr, nil))
 	}()

--- a/main.go
+++ b/main.go
@@ -18,6 +18,8 @@ package main
 
 import (
 	"flag"
+	"log"
+	"net/http"
 	"os"
 	"os/signal"
 	"sync"
@@ -25,6 +27,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/viper"
 
 	"k8s.io/client-go/informers"
@@ -32,6 +35,9 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
+
+// addr tells us what address to have the Prometheus metrics listen on.
+var addr = flag.String("listen-address", ":8080", "The address to listen on for HTTP requests.")
 
 // setup a signal hander to gracefully exit
 func sigHandler() <-chan struct{} {
@@ -102,6 +108,12 @@ func main() {
 	// TODO: Support locking for HA https://github.com/kubernetes/kubernetes/pull/42666
 	eventRouter := NewEventRouter(clientset, eventsInformer)
 	stop := sigHandler()
+
+	// Startup the http listener for Prometheus Metrics endpoint.
+	go func() {
+		http.Handle("/metrics", promhttp.Handler())
+		log.Print(http.ListenAndServe(*addr, nil))
+	}()
 
 	// Startup the EventRouter
 	wg.Add(1)


### PR DESCRIPTION
See #12 

I've added two `CounterVec` metrics to log Kubernetes events (warning and normal) with the following labels:
```
"involved_object_kind",
"involved_object_name",
"involved_object_namespace",
"reason",
"source",
```

Any new types from Kubernetes will need to be added as they come.