### PR TITLE
Adjust metric names to naming conventions.

### DIFF
--- a/eventrouter.go
+++ b/eventrouter.go
@@ -33,9 +33,7 @@ import (
 
 var (
 	kubernetesWarningEventCounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "heptio",
-		Subsystem: "eventrouter",
-		Name:      "warning",
+		Namespace: "heptio_eventrouter_warnings_total",
 		Help:      "Total number of warning events in the kubernetes cluster",
 	}, []string{
 		"involved_object_kind",
@@ -45,9 +43,7 @@ var (
 		"source",
 	})
 	kubernetesNormalEventCounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "heptio",
-		Subsystem: "eventrouter",
-		Name:      "normal",
+		Namespace: "heptio_eventrouter_normal_total",
 		Help:      "Total number of normal events in the kubernetes cluster",
 	}, []string{
 		"involved_object_kind",


### PR DESCRIPTION
All counters should be suffixed with `_total` in Prometheus land.
The `System` and `Subsystem` fields are more of a legacy of the Go client library and a flat representation is recommended.