### PR TITLE
Add StdoutSink to sinks interface

### DIFF
--- a/eventrouter.go
+++ b/eventrouter.go
@@ -33,8 +33,8 @@ import (
 
 var (
 	kubernetesWarningEventCounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "heptio_eventrouter_warnings_total",
-		Help:      "Total number of warning events in the kubernetes cluster",
+		Name: "heptio_eventrouter_warnings_total",
+		Help: "Total number of warning events in the kubernetes cluster",
 	}, []string{
 		"involved_object_kind",
 		"involved_object_name",
@@ -43,8 +43,8 @@ var (
 		"source",
 	})
 	kubernetesNormalEventCounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "heptio_eventrouter_normal_total",
-		Help:      "Total number of normal events in the kubernetes cluster",
+		Name: "heptio_eventrouter_normal_total",
+		Help: "Total number of normal events in the kubernetes cluster",
 	}, []string{
 		"involved_object_kind",
 		"involved_object_name",

--- a/sinks/interfaces.go
+++ b/sinks/interfaces.go
@@ -38,6 +38,8 @@ func ManufactureSink() (e EventSinkInterface) {
 	switch s {
 	case "glog":
 		e = NewGlogSink()
+	case "stdout":
+		e = NewStdoutSink()
 	// case "kafka"
 	// case "logfile"
 	default:

--- a/sinks/stdoutsink.go
+++ b/sinks/stdoutsink.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2017 Heptio Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sinks
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+// StdoutSink is the other basic sink
+// Useful when you already have ELK/EFK Stack that indexes JSON
+type StdoutSink struct {
+	// TODO: create a channel and buffer for scaling
+}
+
+// NewStdoutSink will create a new
+func NewStdoutSink() EventSinkInterface {
+	return &StdoutSink{}
+}
+
+// UpdateEvents implements the EventSinkInterface
+func (gs *StdoutSink) UpdateEvents(eNew *v1.Event, eOld *v1.Event) {
+	var eJSON map[string]interface{}
+	if eOld == nil {
+		eJSON = map[string]interface{}{
+			"verb":  "ADDED",
+			"event": eNew,
+		}
+	} else {
+		eJSON = map[string]interface{}{
+			"verb":      "UPDATED",
+			"event":     eNew,
+			"old_event": eOld,
+		}
+	}
+	if eJSONBytes, err := json.Marshal(eJSON); err == nil {
+		fmt.Println(string(eJSONBytes))
+	} else {
+		fmt.Fprintf(os.Stderr, "Failed to json serialize event: %v", err)
+	}
+}

--- a/sinks/stdoutsink.go
+++ b/sinks/stdoutsink.go
@@ -25,7 +25,10 @@ import (
 )
 
 // StdoutSink is the other basic sink
-// Useful when you already have ELK/EFK Stack that indexes JSON
+// By default, Fluentd/ElasticSearch won't index glog formatted lines
+// By logging raw JSON to stdout, we will get automated indexing which
+// can be queried in Kibana.
+
 type StdoutSink struct {
 	// TODO: create a channel and buffer for scaling
 }


### PR DESCRIPTION
This PR adds a new Sink that prints raw JSON messages to `stdout`.  

By default, the EFK stack does not support indexing of glog formatted messages output from containers.  By logging the raw JSON, EFK is able to index all of the Event object properties. 