### PR TITLE
Add TLS and SASL SCRAM auth support for the Kafka sync

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/rockset/rockset-go-client v0.6.0
 	github.com/sethgrid/pester v0.0.0-20190127155807-68a33a018ad0
 	github.com/spf13/viper v1.4.0
+	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c
 	gopkg.in/jcmturner/goidentity.v3 v3.0.0 // indirect
 	k8s.io/api v0.0.0-20190814101207-0772a1bdf941
 	k8s.io/apimachinery v0.0.0-20190814100815-533d101be9a6

--- a/go.sum
+++ b/go.sum
@@ -266,7 +266,9 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
+github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c h1:u40Z8hqBAAQyv+vATcGgV0YCnDjqSL7/q/JyPhhJSPk=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
+github.com/xdg/stringprep v1.0.0 h1:d9X0esnoa3dFsV0FG35rAT0RIhYFlPq7MiP+DW89La0=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/sinks/interfaces.go
+++ b/sinks/interfaces.go
@@ -65,6 +65,7 @@ func ManufactureSink() (e EventSinkInterface) {
 		viper.SetDefault("kafkaRetryMax", 5)
 		viper.SetDefault("kafkaSaslUser", "")
 		viper.SetDefault("kafkaSaslPwd", "")
+		viper.SetDefault("kafkaSaslMechanism", "")
 
 		brokers := viper.GetStringSlice("kafkaBrokers")
 		topic := viper.GetString("kafkaTopic")
@@ -72,8 +73,9 @@ func ManufactureSink() (e EventSinkInterface) {
 		retryMax := viper.GetInt("kafkaRetryMax")
 		saslUser := viper.GetString("kafkaSaslUser")
 		saslPwd := viper.GetString("kafkaSaslPwd")
+		saslMechanism := viper.GetString("kafkaSaslMechanism")
 
-		e, err := NewKafkaSink(brokers, topic, async, retryMax, saslUser, saslPwd)
+		e, err := NewKafkaSink(brokers, topic, async, retryMax, saslUser, saslPwd, saslMechanism)
 		if err != nil {
 			panic(err.Error())
 		}

--- a/sinks/kafkasink.go
+++ b/sinks/kafkasink.go
@@ -70,18 +70,9 @@ var (
 )
 
 // NewKafkaSinkSink will create a new KafkaSink with default options, returned as an EventSinkInterface
-func NewKafkaSink(brokers []string, topic string, async bool, retryMax int, saslUser, saslPwd, saslMechanism string) (EventSinkInterface, error) {
+func NewKafkaSink(cfg kafkaConfig, topic string) (EventSinkInterface, error) {
 
-	p, err := sinkFactory(&kafkaConfig{
-		Brokers:  brokers,
-		Async:    async,
-		RetryMax: retryMax,
-		SASL:     kafkaSASLConfig{
-			Username:  saslUser,
-			Password:  saslPwd,
-			Mechanism: saslMechanism,
-		},
-	})
+	p, err := sinkFactory(&cfg)
 
 	if err != nil {
 		return nil, err

--- a/sinks/kafkasink.go
+++ b/sinks/kafkasink.go
@@ -36,6 +36,20 @@ type KafkaSink struct {
 	producer interface{}
 }
 
+type kafkaConfig struct {
+	Brokers  []string
+	Async	 bool
+	RetryMax int
+	SASL  	 kafkaSASLConfig
+	TLS 	 *kafkaTLSConfig
+}
+
+type kafkaSASLConfig struct {
+	Username  string
+	Password  string
+	Mechanism string
+}
+
 type kafkaTLSConfig struct {
 	CertFile 	string
 	KeyFile  	string

--- a/sinks/scram_client.go
+++ b/sinks/scram_client.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2017 The Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sinks
+
+import (
+	"crypto/sha512"
+
+	"github.com/xdg/scram"
+)
+
+var (
+	scramSHA256 = scram.SHA256
+	scramSHA512 = scram.HashGeneratorFcn(sha512.New)
+)
+
+type XDGSCRAMClient struct {
+	*scram.Client
+	*scram.ClientConversation
+	scram.HashGeneratorFcn
+}
+
+func (x *XDGSCRAMClient) Begin(userName, password, authzID string) (err error) {
+	x.Client, err = x.HashGeneratorFcn.NewClient(userName, password, authzID)
+	if err == nil {
+		x.ClientConversation = x.Client.NewConversation()
+	}
+	return
+}
+
+func (x *XDGSCRAMClient) Step(challenge string) (string, error) {
+	return x.ClientConversation.Step(challenge)
+}
+
+func (x *XDGSCRAMClient) Done() bool {
+	return x.ClientConversation.Done()
+}


### PR DESCRIPTION
Enable the Kafka sink to:
1. connect to Kafka clusters using TLS connections (by enabling configuration of certificate file, key file and CA cert files), and
2. authenticate using SASL/SCRAM mechanisms (including `SCRAM-SHA-256` and `SCRAM-SHA-512`), in addition to the current default mechanism of SASL/PLAIN