### PR TITLE
Kafka sink test should disable SASL with empty username and password

### DIFF
--- a/tests/kafka/main.go
+++ b/tests/kafka/main.go
@@ -43,7 +43,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	kSink, err := sinks.NewKafkaSink(k.Brokers, k.Topic, k.Async, k.RetryMax, "user", "password")
+	kSink, err := sinks.NewKafkaSink(k.Brokers, k.Topic, k.Async, k.RetryMax, "", "")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Kafka sink test should disable SASL with empty username and password in default.

Signed-off-by: jinrunsen <gasxia@126.com>