### PR TITLE
run on distroless to avoid vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.9
-MAINTAINER Timothy St. Clair "tstclair@heptio.com"  
+FROM gcr.io/distroless/static:latest
+MAINTAINER Timothy St. Clair "tstclair@heptio.com"
 
 WORKDIR /app
-RUN apk update --no-cache && apk add ca-certificates
 ADD eventrouter /app/
 USER nobody:nobody
+COPY --from=busybox /bin/sh /bin/sh
 
 CMD ["/bin/sh", "-c", "/app/eventrouter -v 3 -logtostderr"]


### PR DESCRIPTION
fixes https://github.com/heptiolabs/eventrouter/issues/116

always getting the same error as I get on master:
```
docker run -it --rm a5b155507811
/app/eventrouter: line 2: syntax error: unexpected "("
```
... ideally the build would be done in a different layer of the dockerfile so it's easier to recreate