### PR TITLE
Removing deprecated API

### DIFF
--- a/yaml/eventrouter.yaml
+++ b/yaml/eventrouter.yaml
@@ -18,7 +18,7 @@ metadata:
   name: eventrouter 
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: eventrouter 
@@ -27,7 +27,7 @@ rules:
   resources: ["events"]
   verbs: ["get", "watch", "list"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: eventrouter 


### PR DESCRIPTION
Removing deprecated API's of clusterRole and clusterRoleBinding. New API's are available since kubernetes version 1.8
Signed-off-by: Yuvraj Singh Shekhawat <shekhawatyuvraj1998@gmail.com>